### PR TITLE
Remove create=yes from a ini_file rule

### DIFF
--- a/tasks/orchestrator.yml
+++ b/tasks/orchestrator.yml
@@ -1,5 +1,6 @@
 # CLUES INDIGO Orchestrator plugin configuration
-- ini_file: dest=/etc/clues2/conf.d/plugin-ec3.cfg section="INDIGO ORCHESTRATOR" option=INDIGO_ORCHESTRATOR_DEPLOY_ID value={{ec3_deployment_id}} mode=0600 owner=root create=yes
+- file: path=/etc/clues2/conf.d/plugin-ec3.cfg state=touch mode=0600 owner=root group=root
+- ini_file: dest=/etc/clues2/conf.d/plugin-ec3.cfg section="INDIGO ORCHESTRATOR" option=INDIGO_ORCHESTRATOR_DEPLOY_ID value={{ec3_deployment_id}}
   notify: restart cluesd
 - ini_file: dest=/etc/clues2/conf.d/plugin-ec3.cfg section="INDIGO ORCHESTRATOR" option=INDIGO_ORCHESTRATOR_MAX_INSTANCES value={{ec3_max_instances}}
   notify: restart cluesd


### PR DESCRIPTION
Only supported since Ansible 2.2 and this is the default behavior/value anyway.